### PR TITLE
16: Create Error 404 Not Found Page Layout

### DIFF
--- a/ajentica-team-management-frontend/src/app/app.routes.ts
+++ b/ajentica-team-management-frontend/src/app/app.routes.ts
@@ -3,6 +3,7 @@ import { Dashboard } from './features/dashboard/dashboard';
 import { Teams } from './features/teams/teams';
 import { Members } from './features/members/members';
 import { Projects } from './features/projects/projects';
+import { NotFound } from './shared/components/not-found/not-found';
 
 export const routes: Routes = [
   { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
@@ -21,5 +22,9 @@ export const routes: Routes = [
   {
     path: 'projects',
     component: Projects,
+  },
+  {
+    path: '**',
+    component: NotFound,
   },
 ];

--- a/ajentica-team-management-frontend/src/app/shared/components/not-found/not-found.css
+++ b/ajentica-team-management-frontend/src/app/shared/components/not-found/not-found.css
@@ -1,0 +1,28 @@
+@import 'tailwindcss';
+
+h1 {
+  @apply text-6xl font-bold text-gray-800;
+}
+
+h2 {
+  @apply mt-4 text-gray-600;
+}
+p {
+  @apply mt-4 text-sm text-gray-500;
+}
+
+.error-page-container {
+  @apply flex items-center justify-center h-screen px-4;
+}
+
+.btn-container {
+  @apply mt-6 flex flex-col sm:flex-row gap-4 justify-center;
+}
+
+.btn-back-to-dashboard {
+  @apply bg-(--color-primary) text-white px-4 py-2 rounded-lg hover:bg-(--color-primaryDark) transition;
+}
+
+.btn-go-back {
+  @apply border border-gray-300 px-4 py-2 rounded-lg bg-white hover:bg-gray-100 transition;
+}

--- a/ajentica-team-management-frontend/src/app/shared/components/not-found/not-found.html
+++ b/ajentica-team-management-frontend/src/app/shared/components/not-found/not-found.html
@@ -1,0 +1,1 @@
+<p>not-found works!</p>

--- a/ajentica-team-management-frontend/src/app/shared/components/not-found/not-found.html
+++ b/ajentica-team-management-frontend/src/app/shared/components/not-found/not-found.html
@@ -1,1 +1,15 @@
-<p>not-found works!</p>
+<div class="error-page-container">
+  <div class="text-center max-w-md">
+    <h1 class="header-reset">404</h1>
+
+    <h2 class="header-reset">Page Not Found</h2>
+
+    <p>The page you are looking for doesn’t exist or has been moved.</p>
+
+    <div class="btn-container">
+      <a routerLink="dashboard" class="btn-back-to-dashboard"> Go to Dashboard </a>
+
+      <button (click)="goBack()" class="btn-go-back">Go Back</button>
+    </div>
+  </div>
+</div>

--- a/ajentica-team-management-frontend/src/app/shared/components/not-found/not-found.html
+++ b/ajentica-team-management-frontend/src/app/shared/components/not-found/not-found.html
@@ -1,13 +1,13 @@
 <div class="error-page-container">
   <div class="text-center max-w-md">
-    <h1 class="header-reset">404</h1>
+    <h1 class="header-reset">{{ errorCode }}</h1>
 
-    <h2 class="header-reset">Page Not Found</h2>
+    <h2 class="header-reset">{{ errorTitle }}</h2>
 
-    <p>The page you are looking for doesn’t exist or has been moved.</p>
+    <p>{{ errorMessage }}</p>
 
     <div class="btn-container">
-      <a routerLink="dashboard" class="btn-back-to-dashboard"> Go to Dashboard </a>
+      <a routerLink="/dashboard" class="btn-back-to-dashboard"> Go to Dashboard </a>
 
       <button (click)="goBack()" class="btn-go-back">Go Back</button>
     </div>

--- a/ajentica-team-management-frontend/src/app/shared/components/not-found/not-found.spec.ts
+++ b/ajentica-team-management-frontend/src/app/shared/components/not-found/not-found.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { NotFound } from './not-found';
+
+describe('NotFound', () => {
+  let component: NotFound;
+  let fixture: ComponentFixture<NotFound>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [NotFound],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(NotFound);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/ajentica-team-management-frontend/src/app/shared/components/not-found/not-found.ts
+++ b/ajentica-team-management-frontend/src/app/shared/components/not-found/not-found.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-not-found',
+  imports: [],
+  templateUrl: './not-found.html',
+  styleUrl: './not-found.css',
+})
+export class NotFound {}

--- a/ajentica-team-management-frontend/src/app/shared/components/not-found/not-found.ts
+++ b/ajentica-team-management-frontend/src/app/shared/components/not-found/not-found.ts
@@ -9,6 +9,10 @@ import { Location } from '@angular/common';
   styleUrl: './not-found.css',
 })
 export class NotFound {
+  errorCode: string = '404';
+  errorTitle: string = 'Page Not Found';
+  errorMessage: string = 'The page you are looking for does not exist or has been moved.';
+
   constructor(private location: Location) {}
 
   goBack() {

--- a/ajentica-team-management-frontend/src/app/shared/components/not-found/not-found.ts
+++ b/ajentica-team-management-frontend/src/app/shared/components/not-found/not-found.ts
@@ -1,9 +1,17 @@
 import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { Location } from '@angular/common';
 
 @Component({
   selector: 'app-not-found',
-  imports: [],
+  imports: [RouterLink],
   templateUrl: './not-found.html',
   styleUrl: './not-found.css',
 })
-export class NotFound {}
+export class NotFound {
+  constructor(private location: Location) {}
+
+  goBack() {
+    this.location.back();
+  }
+}


### PR DESCRIPTION
### Summary

This PR introduces the Error 404 not Found page, establishing a foundation for future feature development. And also

### Issue number

- #16 
- #17 
   
### Changes made

- created not found component
- updated routes with not found component
- created a layout for error 404 not found page
- added a button to navigate back to the previous page
- added a message to inform the user that the page is not found
- added styles to error 404 not found page
 
### Testing Steps

1. Run `bun install`
2. Start the development server:
      ```
      bun run dev
      ```
6. Open the application in browser:
      - http://localhost:4200/
8. Verify:
      - App runs without error
      - Error page loads whenever got invalid path
      - Error code present at the page
      - Error title and error message is shown
      - Go to dashboard and go back button present and working properly 
      - All routes are working 
      - No layout breaking issues on the Error page

