### PR TITLE
26: Create Add/Edit Team UI

### DIFF
--- a/ajentica-team-management-frontend/src/app/app.css
+++ b/ajentica-team-management-frontend/src/app/app.css
@@ -1,0 +1,13 @@
+@import 'tailwindcss';
+
+.main-container {
+  @apply flex h-screen;
+}
+
+.right-container {
+  @apply w-5/6 mx-12;
+}
+
+.sidebar {
+  @apply lg:w-1/6;
+}

--- a/ajentica-team-management-frontend/src/app/app.html
+++ b/ajentica-team-management-frontend/src/app/app.html
@@ -1,6 +1,6 @@
-<div class="flex h-screen">
-  <app-sidebar class="lg:w-1/6"></app-sidebar>
-  <div class="w-5/6">
+<div class="main-container">
+  <app-sidebar class="sidebar"></app-sidebar>
+  <div class="right-container">
     <app-header></app-header>
 
     <main>

--- a/ajentica-team-management-frontend/src/app/app.routes.ts
+++ b/ajentica-team-management-frontend/src/app/app.routes.ts
@@ -4,6 +4,9 @@ import { Teams } from './features/teams/teams';
 import { Members } from './features/members/members';
 import { Projects } from './features/projects/projects';
 import { NotFound } from './shared/components/not-found/not-found';
+import { AddTeamPage } from './features/teams/pages/add-team-page/add-team-page';
+import { EditTeamPage } from './features/teams/pages/edit-team-page/edit-team-page';
+import { TeamMainPage } from './features/teams/pages/team-main-page/team-main-page';
 
 export const routes: Routes = [
   { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
@@ -13,7 +16,12 @@ export const routes: Routes = [
   },
   {
     path: 'teams',
-    component: Teams,
+    component: TeamMainPage,
+    children: [
+      { path: '', component: Teams },
+      { path: 'add', component: AddTeamPage },
+      { path: 'edit', component: EditTeamPage },
+    ],
   },
   {
     path: 'members',
@@ -23,6 +31,7 @@ export const routes: Routes = [
     path: 'projects',
     component: Projects,
   },
+
   {
     path: '**',
     component: NotFound,

--- a/ajentica-team-management-frontend/src/app/features/teams/components/add-edit-team-form/add-edit-team-form.css
+++ b/ajentica-team-management-frontend/src/app/features/teams/components/add-edit-team-form/add-edit-team-form.css
@@ -1,7 +1,19 @@
 @import 'tailwindcss';
 
-.input {
-  @apply w-full px-3 py-2 shadow-lg border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 transition overflow-y-auto;
+.form-container {
+  @apply space-y-4 my-4 p-4 w-3/4 mx-auto;
+}
+
+.form-input {
+  @apply w-full focus:outline-none focus:ring-2 focus:ring-blue-500 transition overflow-y-auto;
+}
+
+.option-container {
+  @apply flex flex-col gap-1;
+}
+
+.selection {
+  @apply w-1/2 h-full mb-8;
 }
 
 label {

--- a/ajentica-team-management-frontend/src/app/features/teams/components/add-edit-team-form/add-edit-team-form.css
+++ b/ajentica-team-management-frontend/src/app/features/teams/components/add-edit-team-form/add-edit-team-form.css
@@ -1,0 +1,9 @@
+@import 'tailwindcss';
+
+.input {
+  @apply rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:ring-opacity-50 transition overflow-y-auto;
+}
+
+label {
+  @apply font-semibold;
+}

--- a/ajentica-team-management-frontend/src/app/features/teams/components/add-edit-team-form/add-edit-team-form.css
+++ b/ajentica-team-management-frontend/src/app/features/teams/components/add-edit-team-form/add-edit-team-form.css
@@ -1,7 +1,7 @@
 @import 'tailwindcss';
 
 .input {
-  @apply rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:ring focus:ring-blue-200 focus:ring-opacity-50 transition overflow-y-auto;
+  @apply w-full px-3 py-2 shadow-lg border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 transition overflow-y-auto;
 }
 
 label {

--- a/ajentica-team-management-frontend/src/app/features/teams/components/add-edit-team-form/add-edit-team-form.html
+++ b/ajentica-team-management-frontend/src/app/features/teams/components/add-edit-team-form/add-edit-team-form.html
@@ -1,1 +1,42 @@
-<p>add-edit-team-form works!</p>
+<form class="space-y-4 my-4 p-4" (ngSubmit)="submit()" action="">
+  <div class="">
+    <label for="">Team name</label>
+    <input type="text" name="" id="" class="input" />
+  </div>
+
+  <div>
+    <label>Lead</label>
+    <select [value]="lead()" (change)="setLead($any($event.target).value)" class="input">
+      <option value="">Select Lead</option>
+      @for (l of leads(); track l.id) {
+        <option [value]="l.id">{{ l.name }}</option>
+      }
+    </select>
+  </div>
+
+  <div class="flex gap-4 w-full h-40">
+    <div class="w-1/2 h-full">
+      <label class="label">Projects</label>
+      <select multiple class="input h-8/9" (change)="setProjectsFromSelect($event)">
+        @for (p of projectList(); track p.id) {
+          <option [value]="p.id" [selected]="projects().includes(p.id)">
+            {{ p.name }}
+          </option>
+        }
+      </select>
+    </div>
+
+    <div class="w-1/2 h-full mb-8">
+      <label class="label">Members</label>
+      <select multiple class="input h-8/9" (change)="setMembersFromSelect($event)">
+        @for (m of memberList(); track m.id) {
+          <option [value]="m.id" [selected]="members().includes(m.id)">
+            {{ m.name }}
+          </option>
+        }
+      </select>
+    </div>
+  </div>
+
+  <button class="btn-submit" type="submit">Submit</button>
+</form>

--- a/ajentica-team-management-frontend/src/app/features/teams/components/add-edit-team-form/add-edit-team-form.html
+++ b/ajentica-team-management-frontend/src/app/features/teams/components/add-edit-team-form/add-edit-team-form.html
@@ -1,0 +1,1 @@
+<p>add-edit-team-form works!</p>

--- a/ajentica-team-management-frontend/src/app/features/teams/components/add-edit-team-form/add-edit-team-form.html
+++ b/ajentica-team-management-frontend/src/app/features/teams/components/add-edit-team-form/add-edit-team-form.html
@@ -1,12 +1,12 @@
-<form class="space-y-4 my-4 p-4 w-full" (submit)="submit(); $event.preventDefault()">
-  <div class="">
+<form class="form-container" (submit)="submit(); $event.preventDefault()">
+  <div class="option-container">
     <label for="">Team name</label>
-    <input type="text" name="" id="" class="input" />
+    <input type="text" name="" id="" class="input form-input" />
   </div>
 
-  <div>
+  <div class="option-container">
     <label>Lead</label>
-    <select [value]="lead()" (change)="setLead($any($event.target).value)" class="input">
+    <select [value]="lead()" (change)="setLead($any($event.target).value)" class="input form-input">
       <option value="">Select Lead</option>
       @for (l of leads(); track l.id) {
         <option [value]="l.id">{{ l.name }}</option>
@@ -15,7 +15,7 @@
   </div>
 
   <div class="flex gap-4 w-full h-40">
-    <div class="w-1/2 h-full">
+    <div class="selection option-container">
       <label class="label">Projects</label>
       <app-multi-select
         [options]="projectList()"
@@ -24,7 +24,7 @@
       ></app-multi-select>
     </div>
 
-    <div class="w-1/2 h-full mb-8">
+    <div class="selection option-container">
       <label class="label">Members</label>
       <app-multi-select
         [options]="memberList()"

--- a/ajentica-team-management-frontend/src/app/features/teams/components/add-edit-team-form/add-edit-team-form.html
+++ b/ajentica-team-management-frontend/src/app/features/teams/components/add-edit-team-form/add-edit-team-form.html
@@ -17,24 +17,20 @@
   <div class="flex gap-4 w-full h-40">
     <div class="w-1/2 h-full">
       <label class="label">Projects</label>
-      <select multiple class="input h-8/9" (change)="setProjectsFromSelect($event)">
-        @for (p of projectList(); track p.id) {
-          <option [value]="p.id" [selected]="projects().includes(p.id)">
-            {{ p.name }}
-          </option>
-        }
-      </select>
+      <app-multi-select
+        [options]="projectList()"
+        [selected]="projects()"
+        (selectedChange)="projects.set($event)"
+      ></app-multi-select>
     </div>
 
     <div class="w-1/2 h-full mb-8">
       <label class="label">Members</label>
-      <select multiple class="input h-8/9" (change)="setMembersFromSelect($event)">
-        @for (m of memberList(); track m.id) {
-          <option [value]="m.id" [selected]="members().includes(m.id)">
-            {{ m.name }}
-          </option>
-        }
-      </select>
+      <app-multi-select
+        [options]="memberList()"
+        [selected]="members()"
+        (selectedChange)="members.set($event)"
+      ></app-multi-select>
     </div>
   </div>
 

--- a/ajentica-team-management-frontend/src/app/features/teams/components/add-edit-team-form/add-edit-team-form.html
+++ b/ajentica-team-management-frontend/src/app/features/teams/components/add-edit-team-form/add-edit-team-form.html
@@ -1,4 +1,4 @@
-<form class="space-y-4 my-4 p-4" (ngSubmit)="submit()" action="">
+<form class="space-y-4 my-4 p-4 w-full" (submit)="submit(); $event.preventDefault()">
   <div class="">
     <label for="">Team name</label>
     <input type="text" name="" id="" class="input" />
@@ -38,5 +38,7 @@
     </div>
   </div>
 
-  <button class="btn-submit" type="submit">Submit</button>
+  <div class="text-center">
+    <button class="btn-submit" type="submit">Submit</button>
+  </div>
 </form>

--- a/ajentica-team-management-frontend/src/app/features/teams/components/add-edit-team-form/add-edit-team-form.spec.ts
+++ b/ajentica-team-management-frontend/src/app/features/teams/components/add-edit-team-form/add-edit-team-form.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AddEditTeamForm } from './add-edit-team-form';
+
+describe('AddEditTeamForm', () => {
+  let component: AddEditTeamForm;
+  let fixture: ComponentFixture<AddEditTeamForm>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AddEditTeamForm],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AddEditTeamForm);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/ajentica-team-management-frontend/src/app/features/teams/components/add-edit-team-form/add-edit-team-form.ts
+++ b/ajentica-team-management-frontend/src/app/features/teams/components/add-edit-team-form/add-edit-team-form.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, signal, computed } from '@angular/core';
 
 @Component({
   selector: 'app-add-edit-team-form',
@@ -6,4 +6,61 @@ import { Component } from '@angular/core';
   templateUrl: './add-edit-team-form.html',
   styleUrl: './add-edit-team-form.css',
 })
-export class AddEditTeamForm {}
+export class AddEditTeamForm {
+  teamName = signal<string>('');
+  lead = signal<number | null>(null);
+  projects = signal<number[]>([]);
+  members = signal<number[]>([]);
+
+  leads = signal([
+    { id: 1, name: 'Alice' },
+    { id: 2, name: 'Bob' },
+  ]);
+
+  projectList = signal([
+    { id: 1, name: 'Project A' },
+    { id: 2, name: 'Project B' },
+    { id: 3, name: 'Project C' },
+  ]);
+
+  memberList = signal([
+    { id: 1, name: 'Dev 1' },
+    { id: 2, name: 'Dev 2' },
+    { id: 3, name: 'Dev 3' },
+  ]);
+
+  // ======================
+  // DERIVED STATE (OPTIONAL)
+  // ======================
+
+  formValue = computed(() => ({
+    teamName: this.teamName(),
+    lead: this.lead(),
+    projects: this.projects(),
+    members: this.members(),
+  }));
+
+  setTeamName(value: string) {
+    this.teamName.set(value);
+  }
+
+  setLead(value: string) {
+    this.lead.set(value ? Number(value) : null);
+  }
+
+  setProjectsFromSelect(event: Event) {
+    const select = event.target as HTMLSelectElement;
+    const values = Array.from(select.selectedOptions).map((opt) => Number(opt.value));
+    this.projects.set(values);
+  }
+
+  setMembersFromSelect(event: Event) {
+    const select = event.target as HTMLSelectElement;
+    const values = Array.from(select.selectedOptions).map((opt) => Number(opt.value));
+    this.members.set(values);
+  }
+
+  submit() {
+    console.log('Final Form:', this.formValue());
+  }
+}

--- a/ajentica-team-management-frontend/src/app/features/teams/components/add-edit-team-form/add-edit-team-form.ts
+++ b/ajentica-team-management-frontend/src/app/features/teams/components/add-edit-team-form/add-edit-team-form.ts
@@ -1,8 +1,9 @@
 import { Component, signal, computed } from '@angular/core';
+import { MultiSelect } from '../../../../shared/components/multi-select/multi-select';
 
 @Component({
   selector: 'app-add-edit-team-form',
-  imports: [],
+  imports: [MultiSelect],
   templateUrl: './add-edit-team-form.html',
   styleUrl: './add-edit-team-form.css',
 })
@@ -46,18 +47,6 @@ export class AddEditTeamForm {
 
   setLead(value: string) {
     this.lead.set(value ? Number(value) : null);
-  }
-
-  setProjectsFromSelect(event: Event) {
-    const select = event.target as HTMLSelectElement;
-    const values = Array.from(select.selectedOptions).map((opt) => Number(opt.value));
-    this.projects.set(values);
-  }
-
-  setMembersFromSelect(event: Event) {
-    const select = event.target as HTMLSelectElement;
-    const values = Array.from(select.selectedOptions).map((opt) => Number(opt.value));
-    this.members.set(values);
   }
 
   submit() {

--- a/ajentica-team-management-frontend/src/app/features/teams/components/add-edit-team-form/add-edit-team-form.ts
+++ b/ajentica-team-management-frontend/src/app/features/teams/components/add-edit-team-form/add-edit-team-form.ts
@@ -27,11 +27,11 @@ export class AddEditTeamForm {
     { id: 1, name: 'Dev 1' },
     { id: 2, name: 'Dev 2' },
     { id: 3, name: 'Dev 3' },
+    { id: 4, name: 'Dev 3' },
+    { id: 5, name: 'Dev 3' },
+    { id: 6, name: 'Dev 3' },
+    { id: 7, name: 'Dev 3' },
   ]);
-
-  // ======================
-  // DERIVED STATE (OPTIONAL)
-  // ======================
 
   formValue = computed(() => ({
     teamName: this.teamName(),
@@ -61,6 +61,7 @@ export class AddEditTeamForm {
   }
 
   submit() {
+    console.log('submit button clicked');
     console.log('Final Form:', this.formValue());
   }
 }

--- a/ajentica-team-management-frontend/src/app/features/teams/components/add-edit-team-form/add-edit-team-form.ts
+++ b/ajentica-team-management-frontend/src/app/features/teams/components/add-edit-team-form/add-edit-team-form.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-add-edit-team-form',
+  imports: [],
+  templateUrl: './add-edit-team-form.html',
+  styleUrl: './add-edit-team-form.css',
+})
+export class AddEditTeamForm {}

--- a/ajentica-team-management-frontend/src/app/features/teams/pages/add-team-page/add-team-page.css
+++ b/ajentica-team-management-frontend/src/app/features/teams/pages/add-team-page/add-team-page.css
@@ -1,0 +1,9 @@
+@import 'tailwindcss';
+
+.page-name {
+  @apply text-center;
+}
+
+.page-container {
+  @apply w-3/5 mx-auto;
+}

--- a/ajentica-team-management-frontend/src/app/features/teams/pages/add-team-page/add-team-page.html
+++ b/ajentica-team-management-frontend/src/app/features/teams/pages/add-team-page/add-team-page.html
@@ -1,0 +1,1 @@
+<p>add-team-page works!</p>

--- a/ajentica-team-management-frontend/src/app/features/teams/pages/add-team-page/add-team-page.html
+++ b/ajentica-team-management-frontend/src/app/features/teams/pages/add-team-page/add-team-page.html
@@ -1,1 +1,8 @@
-<p>add-team-page works!</p>
+<div class="mx-6">
+  <app-back-button></app-back-button>
+  <h1 class="header-reset">Add New Team</h1>
+
+  <div>
+    <app-add-edit-team-form></app-add-edit-team-form>
+  </div>
+</div>

--- a/ajentica-team-management-frontend/src/app/features/teams/pages/add-team-page/add-team-page.html
+++ b/ajentica-team-management-frontend/src/app/features/teams/pages/add-team-page/add-team-page.html
@@ -1,8 +1,10 @@
-<div class="mx-6">
+<div>
   <app-back-button></app-back-button>
-  <h1 class="header-reset">Add New Team</h1>
+  <div class="page-container">
+    <h1 class="header-reset page-name">Add New Team</h1>
 
-  <div>
-    <app-add-edit-team-form></app-add-edit-team-form>
+    <div>
+      <app-add-edit-team-form></app-add-edit-team-form>
+    </div>
   </div>
 </div>

--- a/ajentica-team-management-frontend/src/app/features/teams/pages/add-team-page/add-team-page.spec.ts
+++ b/ajentica-team-management-frontend/src/app/features/teams/pages/add-team-page/add-team-page.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AddTeamPage } from './add-team-page';
+
+describe('AddTeamPage', () => {
+  let component: AddTeamPage;
+  let fixture: ComponentFixture<AddTeamPage>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [AddTeamPage],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AddTeamPage);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/ajentica-team-management-frontend/src/app/features/teams/pages/add-team-page/add-team-page.ts
+++ b/ajentica-team-management-frontend/src/app/features/teams/pages/add-team-page/add-team-page.ts
@@ -1,8 +1,10 @@
 import { Component } from '@angular/core';
+import { AddEditTeamForm } from '../../components/add-edit-team-form/add-edit-team-form';
+import { BackButton } from '../../../../shared/components/back-button/back-button';
 
 @Component({
   selector: 'app-add-team-page',
-  imports: [],
+  imports: [AddEditTeamForm, BackButton],
   templateUrl: './add-team-page.html',
   styleUrl: './add-team-page.css',
 })

--- a/ajentica-team-management-frontend/src/app/features/teams/pages/add-team-page/add-team-page.ts
+++ b/ajentica-team-management-frontend/src/app/features/teams/pages/add-team-page/add-team-page.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-add-team-page',
+  imports: [],
+  templateUrl: './add-team-page.html',
+  styleUrl: './add-team-page.css',
+})
+export class AddTeamPage {}

--- a/ajentica-team-management-frontend/src/app/features/teams/pages/edit-team-page/edit-team-page.css
+++ b/ajentica-team-management-frontend/src/app/features/teams/pages/edit-team-page/edit-team-page.css
@@ -1,0 +1,9 @@
+@import 'tailwindcss';
+
+.page-name {
+  @apply text-center;
+}
+
+.page-container {
+  @apply w-3/5 mx-auto;
+}

--- a/ajentica-team-management-frontend/src/app/features/teams/pages/edit-team-page/edit-team-page.html
+++ b/ajentica-team-management-frontend/src/app/features/teams/pages/edit-team-page/edit-team-page.html
@@ -1,0 +1,1 @@
+<p>edit-team-page works!</p>

--- a/ajentica-team-management-frontend/src/app/features/teams/pages/edit-team-page/edit-team-page.html
+++ b/ajentica-team-management-frontend/src/app/features/teams/pages/edit-team-page/edit-team-page.html
@@ -1,8 +1,9 @@
-<div class="mx-6">
+<div>
   <app-back-button></app-back-button>
-  <h1 class="header-reset">Update Team info</h1>
-
-  <div>
-    <app-add-edit-team-form></app-add-edit-team-form>
+  <div class="page-container">
+    <h1 class="header-reset page-name">Update Team info</h1>
+    <div>
+      <app-add-edit-team-form></app-add-edit-team-form>
+    </div>
   </div>
 </div>

--- a/ajentica-team-management-frontend/src/app/features/teams/pages/edit-team-page/edit-team-page.html
+++ b/ajentica-team-management-frontend/src/app/features/teams/pages/edit-team-page/edit-team-page.html
@@ -1,1 +1,4 @@
-<p>edit-team-page works!</p>
+<div class="mx-6">
+  <app-back-button></app-back-button>
+  <h1 class="header-reset">Update Team info</h1>
+</div>

--- a/ajentica-team-management-frontend/src/app/features/teams/pages/edit-team-page/edit-team-page.html
+++ b/ajentica-team-management-frontend/src/app/features/teams/pages/edit-team-page/edit-team-page.html
@@ -1,4 +1,8 @@
 <div class="mx-6">
   <app-back-button></app-back-button>
   <h1 class="header-reset">Update Team info</h1>
+
+  <div>
+    <app-add-edit-team-form></app-add-edit-team-form>
+  </div>
 </div>

--- a/ajentica-team-management-frontend/src/app/features/teams/pages/edit-team-page/edit-team-page.spec.ts
+++ b/ajentica-team-management-frontend/src/app/features/teams/pages/edit-team-page/edit-team-page.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { EditTeamPage } from './edit-team-page';
+
+describe('EditTeamPage', () => {
+  let component: EditTeamPage;
+  let fixture: ComponentFixture<EditTeamPage>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [EditTeamPage],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(EditTeamPage);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/ajentica-team-management-frontend/src/app/features/teams/pages/edit-team-page/edit-team-page.ts
+++ b/ajentica-team-management-frontend/src/app/features/teams/pages/edit-team-page/edit-team-page.ts
@@ -1,9 +1,10 @@
 import { Component } from '@angular/core';
 import { BackButton } from '../../../../shared/components/back-button/back-button';
+import { AddEditTeamForm } from '../../components/add-edit-team-form/add-edit-team-form';
 
 @Component({
   selector: 'app-edit-team-page',
-  imports: [BackButton],
+  imports: [BackButton, AddEditTeamForm],
   templateUrl: './edit-team-page.html',
   styleUrl: './edit-team-page.css',
 })

--- a/ajentica-team-management-frontend/src/app/features/teams/pages/edit-team-page/edit-team-page.ts
+++ b/ajentica-team-management-frontend/src/app/features/teams/pages/edit-team-page/edit-team-page.ts
@@ -1,8 +1,9 @@
 import { Component } from '@angular/core';
+import { BackButton } from '../../../../shared/components/back-button/back-button';
 
 @Component({
   selector: 'app-edit-team-page',
-  imports: [],
+  imports: [BackButton],
   templateUrl: './edit-team-page.html',
   styleUrl: './edit-team-page.css',
 })

--- a/ajentica-team-management-frontend/src/app/features/teams/pages/edit-team-page/edit-team-page.ts
+++ b/ajentica-team-management-frontend/src/app/features/teams/pages/edit-team-page/edit-team-page.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-edit-team-page',
+  imports: [],
+  templateUrl: './edit-team-page.html',
+  styleUrl: './edit-team-page.css',
+})
+export class EditTeamPage {}

--- a/ajentica-team-management-frontend/src/app/features/teams/pages/team-main-page/team-main-page.html
+++ b/ajentica-team-management-frontend/src/app/features/teams/pages/team-main-page/team-main-page.html
@@ -1,0 +1,1 @@
+<router-outlet></router-outlet>

--- a/ajentica-team-management-frontend/src/app/features/teams/pages/team-main-page/team-main-page.spec.ts
+++ b/ajentica-team-management-frontend/src/app/features/teams/pages/team-main-page/team-main-page.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TeamMainPage } from './team-main-page';
+
+describe('TeamMainPage', () => {
+  let component: TeamMainPage;
+  let fixture: ComponentFixture<TeamMainPage>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TeamMainPage],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TeamMainPage);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/ajentica-team-management-frontend/src/app/features/teams/pages/team-main-page/team-main-page.ts
+++ b/ajentica-team-management-frontend/src/app/features/teams/pages/team-main-page/team-main-page.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+import { RouterOutlet } from '@angular/router';
+
+@Component({
+  selector: 'app-team-main-page',
+  imports: [RouterOutlet],
+  templateUrl: './team-main-page.html',
+  styleUrl: './team-main-page.css',
+})
+export class TeamMainPage {}

--- a/ajentica-team-management-frontend/src/app/features/teams/teams.css
+++ b/ajentica-team-management-frontend/src/app/features/teams/teams.css
@@ -2,9 +2,14 @@
 @tailwind utilities;
 
 .teams-container {
-  @apply grid mx-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6;
+  @apply grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6;
 }
-
+.head-container {
+  @apply flex items-center justify-between mb-6;
+}
+.team-name {
+  @apply mb-6;
+}
 .card-header {
   @apply flex justify-between items-center mb-4;
 }

--- a/ajentica-team-management-frontend/src/app/features/teams/teams.html
+++ b/ajentica-team-management-frontend/src/app/features/teams/teams.html
@@ -1,6 +1,6 @@
 <div class="flex items-center justify-between mb-6">
   <h1 class="mb-6">{{ pageName }}</h1>
-  <app-add-button label="Team"></app-add-button>
+  <app-add-button [routerLink]="['add']" label="Team"></app-add-button>
 </div>
 <div class="teams-container">
   <app-card>
@@ -8,7 +8,7 @@
       <h3>Team Name</h3>
 
       <div class="flex gap-2">
-        <button class="btn-icon">
+        <button [routerLink]="['edit']" class="btn-icon">
           <svg lucideSquarePen [size]="20" [strokeWidth]="1"></svg>
         </button>
         <button class="btn-icon"><svg lucideTrash [size]="20" [strokeWidth]="1"></svg></button>

--- a/ajentica-team-management-frontend/src/app/features/teams/teams.html
+++ b/ajentica-team-management-frontend/src/app/features/teams/teams.html
@@ -1,5 +1,5 @@
-<div class="flex items-center justify-between mb-6">
-  <h1 class="mb-6">{{ pageName }}</h1>
+<div class="head-container">
+  <h1 class="team-name">{{ pageName }}</h1>
   <app-add-button [routerLink]="['add']" label="Team"></app-add-button>
 </div>
 <div class="teams-container">

--- a/ajentica-team-management-frontend/src/app/features/teams/teams.ts
+++ b/ajentica-team-management-frontend/src/app/features/teams/teams.ts
@@ -2,10 +2,11 @@ import { Component } from '@angular/core';
 import { Card } from '../../shared/card/card';
 import { LucideSquarePen, LucideTrash } from '@lucide/angular';
 import { AddButton } from '../../shared/components/add-button/add-button';
+import { RouterLink } from '@angular/router';
 
 @Component({
   selector: 'app-teams',
-  imports: [Card, LucideSquarePen, LucideTrash, AddButton, AddButton],
+  imports: [Card, LucideSquarePen, LucideTrash, AddButton, AddButton, RouterLink],
   templateUrl: './teams.html',
   styleUrl: './teams.css',
 })

--- a/ajentica-team-management-frontend/src/app/layout/header/header.css
+++ b/ajentica-team-management-frontend/src/app/layout/header/header.css
@@ -2,11 +2,7 @@
 @tailwind utilities;
 
 .header-container {
-  @apply flex justify-between p-8 overflow-auto;
-}
-
-.header-input {
-  @apply rounded-lg px-4 py-2 w-64 bg-white shadow;
+  @apply flex justify-between py-8 overflow-auto;
 }
 
 .header-image-container {

--- a/ajentica-team-management-frontend/src/app/layout/header/header.html
+++ b/ajentica-team-management-frontend/src/app/layout/header/header.html
@@ -1,5 +1,5 @@
 <div class="header-container">
-  <input type="text" placeholder="Search..." class="header-input" />
+  <input type="text" placeholder="Search..." class="input" />
   <div class="header-profile">
     <svg lucideBell class="cursor-pointer"></svg>
     <div class="header-image-container"></div>

--- a/ajentica-team-management-frontend/src/app/layout/sidebar/sidebar.html
+++ b/ajentica-team-management-frontend/src/app/layout/sidebar/sidebar.html
@@ -1,5 +1,5 @@
 <div class="sidebar-container">
-  <h2 class="">Ajentica Team</h2>
+  <h2>Ajentica Team</h2>
   <nav>
     <a routerLink="dashboard" routerLinkActive="active" class="">Dashboard</a>
     <a routerLink="teams" routerLinkActive="active" class="">Teams</a>

--- a/ajentica-team-management-frontend/src/app/shared/components/back-button/back-button.css
+++ b/ajentica-team-management-frontend/src/app/shared/components/back-button/back-button.css
@@ -1,5 +1,5 @@
 @import 'tailwindcss';
 
 .btn-go-back {
-  @apply border border-gray-300 px-4 py-1 rounded-lg bg-white hover:bg-gray-100 hover:-translate-x-1 transition;
+  @apply border border-gray-300 mx-6 px-4 py-1 rounded-lg bg-white hover:bg-gray-100 hover:-translate-x-1 transition;
 }

--- a/ajentica-team-management-frontend/src/app/shared/components/back-button/back-button.css
+++ b/ajentica-team-management-frontend/src/app/shared/components/back-button/back-button.css
@@ -1,5 +1,5 @@
 @import 'tailwindcss';
 
 .btn-go-back {
-  @apply border border-gray-300 mx-6 px-4 py-1 rounded-lg bg-white hover:bg-gray-100 hover:-translate-x-1 transition;
+  @apply border border-gray-300 px-4 py-1 rounded-lg bg-white hover:bg-gray-100 hover:-translate-x-1 transition;
 }

--- a/ajentica-team-management-frontend/src/app/shared/components/back-button/back-button.css
+++ b/ajentica-team-management-frontend/src/app/shared/components/back-button/back-button.css
@@ -1,0 +1,5 @@
+@import 'tailwindcss';
+
+.btn-go-back {
+  @apply border border-gray-300 px-4 py-1 rounded-lg bg-white hover:bg-gray-100 hover:-translate-x-1 transition;
+}

--- a/ajentica-team-management-frontend/src/app/shared/components/back-button/back-button.html
+++ b/ajentica-team-management-frontend/src/app/shared/components/back-button/back-button.html
@@ -1,1 +1,1 @@
-<button class="btn-go-back"><svg lucideMoveLeft></svg></button>
+<button (click)="goBack()" class="btn-go-back"><svg lucideMoveLeft></svg></button>

--- a/ajentica-team-management-frontend/src/app/shared/components/back-button/back-button.html
+++ b/ajentica-team-management-frontend/src/app/shared/components/back-button/back-button.html
@@ -1,0 +1,1 @@
+<button class="btn-go-back"><svg lucideMoveLeft></svg></button>

--- a/ajentica-team-management-frontend/src/app/shared/components/back-button/back-button.spec.ts
+++ b/ajentica-team-management-frontend/src/app/shared/components/back-button/back-button.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { BackButton } from './back-button';
+
+describe('BackButton', () => {
+  let component: BackButton;
+  let fixture: ComponentFixture<BackButton>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [BackButton],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(BackButton);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/ajentica-team-management-frontend/src/app/shared/components/back-button/back-button.ts
+++ b/ajentica-team-management-frontend/src/app/shared/components/back-button/back-button.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { LucideMoveLeft } from '@lucide/angular';
+import { Location } from '@angular/common';
 
 @Component({
   selector: 'app-back-button',
@@ -7,4 +8,10 @@ import { LucideMoveLeft } from '@lucide/angular';
   templateUrl: './back-button.html',
   styleUrl: './back-button.css',
 })
-export class BackButton {}
+export class BackButton {
+  constructor(private location: Location) {}
+
+  goBack() {
+    this.location.back();
+  }
+}

--- a/ajentica-team-management-frontend/src/app/shared/components/back-button/back-button.ts
+++ b/ajentica-team-management-frontend/src/app/shared/components/back-button/back-button.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+import { LucideMoveLeft } from '@lucide/angular';
+
+@Component({
+  selector: 'app-back-button',
+  imports: [LucideMoveLeft],
+  templateUrl: './back-button.html',
+  styleUrl: './back-button.css',
+})
+export class BackButton {}

--- a/ajentica-team-management-frontend/src/app/shared/components/multi-select/multi-select.css
+++ b/ajentica-team-management-frontend/src/app/shared/components/multi-select/multi-select.css
@@ -1,0 +1,23 @@
+@import 'tailwindcss';
+
+@layer components {
+  .multi-select {
+    @apply relative w-full;
+  }
+}
+
+.option-selector {
+  @apply border border-gray-300 shadow-lg rounded-lg px-3 py-2 flex flex-wrap gap-2 cursor-pointer min-h-12;
+}
+
+.options {
+  @apply bg-white text-blue-700 px-2 py-1 rounded-lg flex items-center gap-1;
+}
+
+.dropdown-container {
+  @apply absolute w-full mt-1 border border-gray-300 rounded-lg bg-white shadow-lg max-h-48 overflow-auto z-10;
+}
+
+.dropdown-option {
+  @apply px-3 py-2 hover:bg-gray-100 flex items-center gap-2 cursor-pointer;
+}

--- a/ajentica-team-management-frontend/src/app/shared/components/multi-select/multi-select.html
+++ b/ajentica-team-management-frontend/src/app/shared/components/multi-select/multi-select.html
@@ -1,0 +1,35 @@
+<div class="multi-select relative w-full">
+  <!-- Selected Chips -->
+  <div
+    class="border rounded-lg px-3 py-2 flex flex-wrap gap-2 cursor-pointer min-h-12"
+    (click)="toggleDropdown()"
+  >
+    @if (selected().length === 0) {
+      <span class="text-gray-400">Select options...</span>
+    }
+
+    @for (item of options(); track item.id) {
+      @if (selected().includes(item.id)) {
+        <span class="bg-blue-100 text-blue-700 px-2 py-1 rounded flex items-center gap-1">
+          {{ item.name }}
+          <button type="button" (click)="removeItem(item.id); $event.stopPropagation()">✕</button>
+        </span>
+      }
+    }
+  </div>
+
+  <!-- Dropdown -->
+  @if (isOpen()) {
+    <div class="absolute w-full mt-1 border rounded-lg bg-white shadow max-h-48 overflow-auto z-10">
+      @for (item of options(); track item.id) {
+        <div
+          class="px-3 py-2 hover:bg-gray-100 flex items-center gap-2 cursor-pointer"
+          (click)="toggleOption(item.id)"
+        >
+          <input type="checkbox" [checked]="selected().includes(item.id)" />
+          {{ item.name }}
+        </div>
+      }
+    </div>
+  }
+</div>

--- a/ajentica-team-management-frontend/src/app/shared/components/multi-select/multi-select.html
+++ b/ajentica-team-management-frontend/src/app/shared/components/multi-select/multi-select.html
@@ -1,6 +1,6 @@
 <div class="multi-select">
   <!-- Selected Chips -->
-  <div class="option-selector" (click)="toggleDropdown()">
+  <div class="option-selector bg-white" (click)="toggleDropdown()">
     @if (selected().length === 0) {
       <span class="text-gray-400">Select options...</span>
     }

--- a/ajentica-team-management-frontend/src/app/shared/components/multi-select/multi-select.html
+++ b/ajentica-team-management-frontend/src/app/shared/components/multi-select/multi-select.html
@@ -1,18 +1,21 @@
-<div class="multi-select relative w-full">
+<div class="multi-select">
   <!-- Selected Chips -->
-  <div
-    class="border rounded-lg px-3 py-2 flex flex-wrap gap-2 cursor-pointer min-h-12"
-    (click)="toggleDropdown()"
-  >
+  <div class="option-selector" (click)="toggleDropdown()">
     @if (selected().length === 0) {
       <span class="text-gray-400">Select options...</span>
     }
 
     @for (item of options(); track item.id) {
       @if (selected().includes(item.id)) {
-        <span class="bg-blue-100 text-blue-700 px-2 py-1 rounded flex items-center gap-1">
+        <span class="options">
           {{ item.name }}
-          <button type="button" (click)="removeItem(item.id); $event.stopPropagation()">✕</button>
+          <button
+            type="button"
+            class="cursor-pointer"
+            (click)="removeItem(item.id); $event.stopPropagation()"
+          >
+            ✕
+          </button>
         </span>
       }
     }
@@ -20,12 +23,9 @@
 
   <!-- Dropdown -->
   @if (isOpen()) {
-    <div class="absolute w-full mt-1 border rounded-lg bg-white shadow max-h-48 overflow-auto z-10">
+    <div class="dropdown-container">
       @for (item of options(); track item.id) {
-        <div
-          class="px-3 py-2 hover:bg-gray-100 flex items-center gap-2 cursor-pointer"
-          (click)="toggleOption(item.id)"
-        >
+        <div class="dropdown-option" (click)="toggleOption(item.id)">
           <input type="checkbox" [checked]="selected().includes(item.id)" />
           {{ item.name }}
         </div>

--- a/ajentica-team-management-frontend/src/app/shared/components/multi-select/multi-select.spec.ts
+++ b/ajentica-team-management-frontend/src/app/shared/components/multi-select/multi-select.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MultiSelect } from './multi-select';
+
+describe('MultiSelect', () => {
+  let component: MultiSelect;
+  let fixture: ComponentFixture<MultiSelect>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MultiSelect],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MultiSelect);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/ajentica-team-management-frontend/src/app/shared/components/multi-select/multi-select.ts
+++ b/ajentica-team-management-frontend/src/app/shared/components/multi-select/multi-select.ts
@@ -1,0 +1,45 @@
+import { Component, input, signal, output, HostListener } from '@angular/core';
+
+@Component({
+  selector: 'app-multi-select',
+  imports: [],
+  templateUrl: './multi-select.html',
+  styleUrl: './multi-select.css',
+})
+export class MultiSelect {
+  options = input<{ id: number; name: string }[]>([]);
+  selected = input<number[]>([]);
+  selectedChange = output<number[]>();
+
+  isOpen = signal(false);
+
+  toggleDropdown() {
+    this.isOpen.update((v) => !v);
+  }
+
+  isSelected(id: number) {
+    return this.selected().includes(id);
+  }
+
+  toggleOption(id: number) {
+    const current = this.selected();
+
+    if (current.includes(id)) {
+      this.selectedChange.emit(current.filter((i) => i !== id));
+    } else {
+      this.selectedChange.emit([...current, id]);
+    }
+  }
+
+  removeItem(id: number) {
+    this.selectedChange.emit(this.selected().filter((i) => i !== id));
+  }
+
+  @HostListener('document:click', ['$event'])
+  closeOutside(event: Event) {
+    const target = event.target as HTMLElement;
+    if (!target.closest('.multi-select')) {
+      this.isOpen.set(false);
+    }
+  }
+}

--- a/ajentica-team-management-frontend/src/styles/styles.css
+++ b/ajentica-team-management-frontend/src/styles/styles.css
@@ -35,7 +35,7 @@ body {
 
 /* Typography */
 h1 {
-  @apply text-3xl font-bold mx-4 p-2;
+  @apply text-3xl font-bold mt-4;
 }
 
 ul {

--- a/ajentica-team-management-frontend/src/styles/styles.css
+++ b/ajentica-team-management-frontend/src/styles/styles.css
@@ -35,7 +35,7 @@ body {
 
 /* Typography */
 h1 {
-  @apply text-3xl font-bold mt-4;
+  @apply text-3xl font-bold mx-6 mt-4;
 }
 
 ul {

--- a/ajentica-team-management-frontend/src/styles/styles.css
+++ b/ajentica-team-management-frontend/src/styles/styles.css
@@ -35,7 +35,7 @@ body {
 
 /* Typography */
 h1 {
-  @apply text-3xl font-bold mx-6 mt-4;
+  @apply text-3xl font-bold mt-4;
 }
 
 ul {
@@ -69,4 +69,8 @@ a {
 
 a.active {
   color: var(--color-primary);
+}
+
+.input {
+  @apply rounded-lg px-4 py-2 w-64 bg-white shadow;
 }

--- a/ajentica-team-management-frontend/src/styles/styles.css
+++ b/ajentica-team-management-frontend/src/styles/styles.css
@@ -58,6 +58,10 @@ h3 {
   @apply bg-(--color-primary) gap-2 items-center text-white font-semibold text-sm mx-6 my-2 px-4 py-2 rounded-xl hover:bg-(--color-primaryDark) cursor-pointer transition-colors duration-200;
 }
 
+.btn-submit {
+  @apply m-4 px-4 py-2 bg-(--color-primary) text-white font-semibold text-sm mx-6 my-2  rounded-xl hover:bg-(--color-primaryDark) cursor-pointer transition-colors duration-200;
+}
+
 /* Links */
 a {
   @apply transition-colors duration-200 text-gray-700 hover:rounded-lg hover:bg-gray-200 cursor-pointer p-2;

--- a/ajentica-team-management-frontend/src/styles/styles.css
+++ b/ajentica-team-management-frontend/src/styles/styles.css
@@ -59,7 +59,7 @@ h3 {
 }
 
 .btn-submit {
-  @apply m-4 px-4 py-2 bg-(--color-primary) text-white font-semibold text-sm mx-6 my-2  rounded-xl hover:bg-(--color-primaryDark) cursor-pointer transition-colors duration-200;
+  @apply px-4 py-2 bg-(--color-primary) text-white font-semibold text-sm my-2  rounded-xl hover:bg-(--color-primaryDark) cursor-pointer transition-colors duration-200;
 }
 
 /* Links */


### PR DESCRIPTION
### Summary

This PR implements the Add/Edit Team pages along with reusable form components and updates the Teams routing structure to support nested pages. It also introduces a Back Button component to improve navigation within team-related workflows.

### Issue number

- #26

### Changes made

- created add-edit-team-form component  
- created add-team-page component  
- created edit-team-page component  
- refactored Teams page routing to support sub-pages  
- added Team Main Page with router outlet  
- updated routes for Teams page and nested routes  
- added Back Button component  
- integrated Back Button into Edit Team page  
- created reusable form structure for team forms  
- integrated reusable form into Edit Team page  
- fixed UI issues in form layout  
- added form to Add Team page  
- updated styles for better consistency  
- verified form submission via console logging  

### Testing Steps

1. Run `bun install`  
2. Start the development server:
```
bun run dev
```
3. Open the application in browser:
```
http://localhost:4200/
```
4. Verify:
   - App runs without error  
   - Teams page routing works with nested routes  
   - Navigation to Add Team and Edit Team pages works correctly  
   - Back Button navigates properly from Edit page  
   - Reusable form renders correctly in both Add and Edit pages  
   - Form UI is consistent and not broken  
   - Form submission logs data in console  
   - No layout breaking issues across routes  