### PR TITLE
28: Add Delete Confirmation UI

### DIFF
--- a/ajentica-team-management-frontend/.gitignore
+++ b/ajentica-team-management-frontend/.gitignore
@@ -63,3 +63,5 @@ Thumbs.db
 # Optional SSR
 .server/
 .prerendered/
+
+temp/

--- a/ajentica-team-management-frontend/src/app/features/teams/teams.html
+++ b/ajentica-team-management-frontend/src/app/features/teams/teams.html
@@ -12,7 +12,9 @@
           <button [routerLink]="['edit']" class="btn-icon">
             <svg lucideSquarePen [size]="20" [strokeWidth]="1"></svg>
           </button>
-          <button class="btn-icon"><svg lucideTrash [size]="20" [strokeWidth]="1"></svg></button>
+          <button (click)="openModal('Team Alpha')" class="btn-icon">
+            <svg lucideTrash [size]="20" [strokeWidth]="1"></svg>
+          </button>
         </div>
       </div>
       <p>Team lead: John Doe</p>
@@ -22,3 +24,10 @@
     </app-card>
   </div>
 </section>
+
+<app-confirm-modal
+  [isOpen]="isModalOpen()"
+  [itemName]="selectedName()"
+  (confirm)="handleConfirm()"
+  (cancel)="closeModal()"
+></app-confirm-modal>

--- a/ajentica-team-management-frontend/src/app/features/teams/teams.ts
+++ b/ajentica-team-management-frontend/src/app/features/teams/teams.ts
@@ -1,9 +1,10 @@
-import { Component } from '@angular/core';
+import { Component, signal } from '@angular/core';
 import { Card } from '../../shared/card/card';
 import { LucideSquarePen, LucideTrash } from '@lucide/angular';
 import { AddButton } from '../../shared/components/add-button/add-button';
 import { RouterLink } from '@angular/router';
 import { ViewDetailsButton } from '../../shared/components/view-details-button/view-details-button';
+import { ConfirmModal } from '../../shared/components/confirm-modal/confirm-modal';
 
 @Component({
   selector: 'app-teams',
@@ -15,10 +16,28 @@ import { ViewDetailsButton } from '../../shared/components/view-details-button/v
     AddButton,
     RouterLink,
     ViewDetailsButton,
+    ConfirmModal,
   ],
   templateUrl: './teams.html',
   styleUrl: './teams.css',
 })
 export class Teams {
   pageName: string = 'Teams';
+
+  isModalOpen = signal(false);
+  selectedName = signal('');
+
+  openModal(name: string) {
+    this.selectedName.set(name);
+    this.isModalOpen.set(true);
+  }
+
+  closeModal() {
+    this.isModalOpen.set(false);
+  }
+
+  handleConfirm() {
+    console.log('Confirmed delete for:', this.selectedName());
+    this.closeModal();
+  }
 }

--- a/ajentica-team-management-frontend/src/app/shared/components/confirm-modal/confirm-modal.html
+++ b/ajentica-team-management-frontend/src/app/shared/components/confirm-modal/confirm-modal.html
@@ -1,0 +1,1 @@
+<p>confirm-modal works!</p>

--- a/ajentica-team-management-frontend/src/app/shared/components/confirm-modal/confirm-modal.html
+++ b/ajentica-team-management-frontend/src/app/shared/components/confirm-modal/confirm-modal.html
@@ -1,1 +1,23 @@
-<p>confirm-modal works!</p>
+@if (isOpen()) {
+  <div class="fixed inset-0 flex items-center justify-center bg-black/50 z-50">
+    <div class="bg-white rounded-xl p-6 w-92 shadow-lg">
+      <h2 class="text-lg font-semibold mb-4">Confirm Delete</h2>
+
+      <p class="mb-6">
+        Are you sure you want to delete
+        <span class="font-semibold">'{{ itemName() }}'</span>?
+      </p>
+
+      <div class="flex justify-end gap-3">
+        <button class="px-4 py-2 border rounded-lg" (click)="close()">Cancel</button>
+
+        <button
+          class="px-4 py-2 bg-red-500 text-white rounded-lg hover:bg-red-600"
+          (click)="onConfirm()"
+        >
+          Delete
+        </button>
+      </div>
+    </div>
+  </div>
+}

--- a/ajentica-team-management-frontend/src/app/shared/components/confirm-modal/confirm-modal.spec.ts
+++ b/ajentica-team-management-frontend/src/app/shared/components/confirm-modal/confirm-modal.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ConfirmModal } from './confirm-modal';
+
+describe('ConfirmModal', () => {
+  let component: ConfirmModal;
+  let fixture: ComponentFixture<ConfirmModal>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ConfirmModal],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ConfirmModal);
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/ajentica-team-management-frontend/src/app/shared/components/confirm-modal/confirm-modal.ts
+++ b/ajentica-team-management-frontend/src/app/shared/components/confirm-modal/confirm-modal.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-confirm-modal',
+  imports: [],
+  templateUrl: './confirm-modal.html',
+  styleUrl: './confirm-modal.css',
+})
+export class ConfirmModal {}

--- a/ajentica-team-management-frontend/src/app/shared/components/confirm-modal/confirm-modal.ts
+++ b/ajentica-team-management-frontend/src/app/shared/components/confirm-modal/confirm-modal.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, input, output, signal } from '@angular/core';
 
 @Component({
   selector: 'app-confirm-modal',
@@ -6,4 +6,20 @@ import { Component } from '@angular/core';
   templateUrl: './confirm-modal.html',
   styleUrl: './confirm-modal.css',
 })
-export class ConfirmModal {}
+export class ConfirmModal {
+  itemName = input<string>('');
+
+  isOpen = input<boolean>(false);
+
+  confirm = output<void>();
+  cancel = output<void>();
+
+  close() {
+    this.cancel.emit();
+  }
+
+  onConfirm() {
+    console.log('content deleted');
+    this.confirm.emit();
+  }
+}


### PR DESCRIPTION
### Summary

This PR introduces a reusable Modal system along with a Confirm Modal component to handle user confirmations. It integrates the modal into the Teams page and connects it with delete actions to improve user interaction and feedback.

### Issue number

- #28

### Changes made

- created reusable modal component
- implemented modal UI and core functionality
- created confirm modal component for user confirmation actions
- integrated modal into Teams page
- connected delete icon action to trigger confirm modal
- added logic in Teams page to control modal visibility and actions

### Testing Steps

1. Run `bun install`
2. Start the development server:

```
bun run dev
```

3. Open the application in browser:

- http://localhost:4200/

4. Verify:
   - App runs without error
   - Modal component renders correctly
   - Confirm modal appears when delete icon is clicked
   - Modal UI is consistent with application styles
   - Modal open/close functionality works properly
   - Delete action triggers modal correctly
   - No layout breaking issues on Teams page
