### PR TITLE
45: Complete CRUD Operation for Teams feature

### DIFF
--- a/ajentica-team-management-frontend/src/app/core/services/team.service.ts
+++ b/ajentica-team-management-frontend/src/app/core/services/team.service.ts
@@ -41,8 +41,13 @@ export class TeamService {
 
   // ✅ Delete
   deleteTeam(id: number) {
-    this.api.delete(id).subscribe(() => {
-      this.teams.update((prev) => prev.filter((t) => t.id !== id));
+    this.api.delete(id).subscribe({
+      next: () => {
+        this.loadTeams();
+      },
+      error: (err) => {
+        console.error('Delete failed', err);
+      },
     });
   }
 }

--- a/ajentica-team-management-frontend/src/app/features/teams/teams.html
+++ b/ajentica-team-management-frontend/src/app/features/teams/teams.html
@@ -13,7 +13,7 @@
             <button [routerLink]="['/teams/edit', team.id]" class="btn-icon">
               <svg lucideSquarePen [size]="20" [strokeWidth]="1"></svg>
             </button>
-            <button (click)="openModal('Team Alpha')" class="btn-icon">
+            <button (click)="openModal(team)" class="btn-icon">
               <svg lucideTrash [size]="20" [strokeWidth]="1"></svg>
             </button>
           </div>

--- a/ajentica-team-management-frontend/src/app/features/teams/teams.ts
+++ b/ajentica-team-management-frontend/src/app/features/teams/teams.ts
@@ -35,28 +35,32 @@ export class Teams {
     console.log('Teams value:', this.teams());
   }
 
-  getMemberNames(team: any) {
-    return team.members.map((m: any) => m.name).join(', ');
-  }
-
-  getProjectNames(team: any) {
-    return team.projects.map((p: any) => p.name).join(', ');
-  }
-
+  selectedTeamId = signal<number | null>(null);
+  selectedName = signal<string>('');
   isModalOpen = signal(false);
-  selectedName = signal('');
 
-  openModal(name: string) {
-    this.selectedName.set(name);
+  // ✅ OPEN MODAL
+  openModal(team: any) {
+    this.selectedTeamId.set(team.id);
+    this.selectedName.set(team.name);
     this.isModalOpen.set(true);
   }
 
+  // ✅ CLOSE MODAL
   closeModal() {
     this.isModalOpen.set(false);
+    this.selectedTeamId.set(null);
+    this.selectedName.set('');
   }
 
+  // ✅ CONFIRM DELETE
   handleConfirm() {
-    console.log('Confirmed delete for:', this.selectedName());
+    const id = this.selectedTeamId();
+
+    if (id !== null) {
+      this.teamService.deleteTeam(id);
+    }
+
     this.closeModal();
   }
 }

--- a/ajentica-team-management-frontend/src/app/shared/components/confirm-modal/confirm-modal.ts
+++ b/ajentica-team-management-frontend/src/app/shared/components/confirm-modal/confirm-modal.ts
@@ -1,4 +1,4 @@
-import { Component, input, output, signal } from '@angular/core';
+import { Component, input, output } from '@angular/core';
 
 @Component({
   selector: 'app-confirm-modal',
@@ -8,7 +8,6 @@ import { Component, input, output, signal } from '@angular/core';
 })
 export class ConfirmModal {
   itemName = input<string>('');
-
   isOpen = input<boolean>(false);
 
   confirm = output<void>();


### PR DESCRIPTION
### Summary

This PR completes the CRUD operations for the Team feature by refining the deletion workflow. It integrates the confirmation modal with the delete logic and cleans up the codebase by removing unused functions.

### Issue number

- #45

### Changes made

- updated the delete method
- updated the confirm modal component
- updated the team page to handle the delete method
- removed redundant function

### Testing Steps

1. Run `bun install`
2. Start the development server:

```
bun run dev
```

3. Open the application in browser:

```
 http://localhost:4200/
```

4. Verify:
   - App runs without error
   - Deleting a team triggers the updated confirmation modal
   - Confirming the deletion successfully calls the API and updates the UI
   - Redundant functions are removed without affecting existing logic


